### PR TITLE
Configure Gradle to use Java preview features

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'application'
+    id 'application'
 }
 
 group = 'uk.gemwire'
@@ -8,6 +8,7 @@ version = '0.1'
 
 application {
     mainClassName = 'uk.gemwire.mcpconvert.Main'
+    applicationDefaultJvmArgs += ["--enable-preview"]
 }
 
 java {
@@ -23,5 +24,19 @@ repositories {
 }
 
 dependencies {
-	implementation group: 'net.minecraftforge', name: 'srgutils', version: '0.3.0'
+    implementation group: 'net.minecraftforge', name: 'srgutils', version: '0.3.0'
+}
+
+// Enable preview features, so we can have records and such
+
+tasks.withType(JavaCompile) {
+    options.compilerArgs += '--enable-preview'
+}
+
+tasks.withType(Test) {
+    jvmArgs += "--enable-preview"
+}
+
+tasks.withType(JavaExec) {
+    jvmArgs += "--enable-preview"
 }


### PR DESCRIPTION
Enables the usage of Java preview features through Gradle, by adding the `--enable-preview` flag on `JavaCompile`, `Test`, and `JavaExec` tasks as suggested by the [Gradle 6.8.1 Userguide, Building Java & JVM projects § Enabling Java preview features](https://docs.gradle.org/current/userguide/building_java_projects.html#sec:feature_preview).

From my test, IntelliJ IDEA automatically picked up the preview flags and changed the project language level, but it is advised to check it anyway if errors still persist.