### PR TITLE
Use Jimfs to hold in-memory copy of MCP data zip

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,10 +6,18 @@ group = 'uk.gemwire'
 archivesBaseName = 'mcpconvert'
 version = '0.1'
 
+repositories {
+    mavenCentral()
+    jcenter()
+    maven { url = 'https://files.minecraftforge.net/maven/' }
+}
+
 dependencies {
+    implementation group: 'net.minecraftforge', name: 'srgutils', version: '0.3.0'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.11.2'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.11.2'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.11.2'
+    implementation group: 'com.google.jimfs', name: 'jimfs', version: '1.2'
 }
 
 application {
@@ -21,16 +29,6 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(15)
     }
-}
-
-repositories {
-    mavenCentral()
-    jcenter()
-    maven { url = 'https://files.minecraftforge.net/maven/' }
-}
-
-dependencies {
-    implementation group: 'net.minecraftforge', name: 'srgutils', version: '0.3.0'
 }
 
 // Enable preview features, so we can have records and such

--- a/src/main/java/uk/gemwire/mcpconvert/download/MCPData.java
+++ b/src/main/java/uk/gemwire/mcpconvert/download/MCPData.java
@@ -1,29 +1,24 @@
 package uk.gemwire.mcpconvert.download;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.util.zip.ZipFile;
 
 import uk.gemwire.mcpconvert.download.util.Caching;
 
 public class MCPData {
-
-    public static ZipFile provide(String version) throws IOException {
-        return new ZipFile(provideFile(version));
+    public static Path provideCachedFile(String version) throws IOException {
+        String url = "https://files.minecraftforge.net/maven/de/oceanlabs/mcp/mcp/{version}/mcp-{version}-srg.zip"
+            .replace("{version}", version);
+        return Caching.cached("mcp-{version}-srg.zip".replace("{version}", version), (path) -> downloadFileFromUrl(url, path));
     }
 
-    public static File provideFile(String version) throws IOException {
-        String url = "https://files.minecraftforge.net/maven/de/oceanlabs/mcp/mcp/{version}/mcp-{version}-srg.zip".replace("{version}", version);
-        return Caching.cached("mcp-{version}-srg.zip".replace("{version}", version), (file) -> downloadFileFromUrl(url, file));
-    }
-
-    private static void downloadFileFromUrl(String url, File destination) throws IOException {
+    private static void downloadFileFromUrl(String url, Path destination) throws IOException {
         try (InputStream in = new URL(url).openStream()) {
-            Files.copy(in, destination.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            Files.copy(in, destination, StandardCopyOption.REPLACE_EXISTING);
         }
     }
 

--- a/src/main/java/uk/gemwire/mcpconvert/download/util/Caching.java
+++ b/src/main/java/uk/gemwire/mcpconvert/download/util/Caching.java
@@ -1,25 +1,26 @@
 package uk.gemwire.mcpconvert.download.util;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import uk.gemwire.mcpconvert.download.util.io.IOConsumer;
 
 public interface Caching {
 
-    File CACHE = new File(".cache");
+    Path CACHE = Path.of(".cache");
 
-    static File cached(String path, IOConsumer<File> generator) throws IOException {
-        CACHE.mkdirs();
-        return cached(new File(CACHE, path), generator);
+    static Path cached(String path, IOConsumer<Path> generator) throws IOException {
+        Files.createDirectories(CACHE);
+        return cached(CACHE.resolve(path), generator);
     }
 
-    static File cached(File cached, IOConsumer<File> generator) throws IOException {
-        if (cached.exists()) return cached;
+    static Path cached(Path cached, IOConsumer<Path> generator) throws IOException {
+        if (Files.exists(cached)) return cached;
 
         generator.accept(cached);
 
-        if (!cached.exists()) throw new AssertionError();
+        if (!Files.exists(cached)) throw new AssertionError("Generator did not generate the cached file");
 
         return cached;
     }


### PR DESCRIPTION
Adds the [Jimfs](https://github.com/google/jimfs) library to hold all files in-memory while being processed, to avoid writing to disk until all data is processed. This moves MCPConvert from using `java.io` to `java.nio`, with all the nifty features (such as avoiding `ZipFile`, and near-transparency on how files can be handled from where they are handled).