### PR TITLE
Fix default function name for config.json generator

### DIFF
--- a/src/main/java/uk/gemwire/mcpconvert/cli/ConfigFileGenerator.java
+++ b/src/main/java/uk/gemwire/mcpconvert/cli/ConfigFileGenerator.java
@@ -196,7 +196,7 @@ public class ConfigFileGenerator {
 
         final String verPlaceholder = "CHANGE_ME";
 
-        functions.add(ConfigFunction.create("mcinject")
+        functions.add(ConfigFunction.create("mcinjector")
             .version("de.oceanlabs.mcp:mcinjector:" + verPlaceholder + ":fatjar")
             .args("--in", "{input}", "--out", "{output}", "--log", "{log}", "--lvt=LVT", "--exc", "{exceptions}", "--acc",
                 "{access}", "--ctr", "{constructors}")


### PR DESCRIPTION
Fixes the default function name for MCInjector from `mcinject` to `mcinjector` in the input config.json generator.