### PR TITLE
Refactor JoinedExcSplitter and add tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,16 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.11.2'
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.11.2'
     implementation group: 'com.google.jimfs', name: 'jimfs', version: '1.2'
+
+    testImplementation(platform('org.junit:junit-bom:5.7.1'))
+    testImplementation('org.junit.jupiter:junit-jupiter')
+}
+
+test {
+    useJUnitPlatform()
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
 }
 
 application {

--- a/src/main/java/uk/gemwire/mcpconvert/convert/JoinedExcSplitter.java
+++ b/src/main/java/uk/gemwire/mcpconvert/convert/JoinedExcSplitter.java
@@ -7,19 +7,24 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static java.util.regex.Pattern.compile;
 
 /**
  * @author Sm0keySa1m0n
  */
 public class JoinedExcSplitter {
 
-    private static final Pattern CONSTRUCTOR_REGEX = Pattern.compile("(\\.<init>)(\\(\\S*)(=\\S*\\|p_i)(\\d*)");
-    private static final Pattern EXCEPTION_REGEX = Pattern.compile("(\\(\\S*\\)\\S*)=(\\S+)\\|");
-    private static final Pattern ACCESS_REGEX = Pattern.compile("(\\S*)\\.(\\S*)(\\(\\S*\\)\\S*)-Access=(\\S*)");
+    private static final Pattern CONSTRUCTOR_REGEX =
+        compile("(?<class>\\S*?)(?:\\.<init>)(?<desc>\\S*)(?:=\\S*\\|p_i)(?<id>\\d*)");
+    private static final Pattern EXCEPTION_REGEX =
+        compile("(?<class>\\S*)\\.(?<func>\\S*)(?<desc>\\(\\S*\\)\\S*)=(?<exceptions>\\S+)\\|");
+    private static final Pattern ACCESS_REGEX =
+        compile("(?<class>\\S*)\\.(?<func>\\S*)(?<desc>\\(\\S*\\)[^=\\s]).*-Access=(?<access>\\S*)");
 
-    @SuppressWarnings("StringBufferReplaceableByString")
     public static Result parseExc(Path excFile) throws IOException {
         List<String> lines = Files.readAllLines(excFile, StandardCharsets.UTF_8);
 
@@ -27,78 +32,87 @@ public class JoinedExcSplitter {
         List<String> exceptionLines = new ArrayList<>();
         List<String> accessLines = new ArrayList<>();
 
-        for (String line : lines) {
-            boolean lineMatched = false;
-            // If we match ".<init>" we're a constructor.
-            Matcher constructorMatcher = CONSTRUCTOR_REGEX.matcher(line);
-            // If we match (SOMETHING)SOMETHING=SOMETHING|, we're an exception line
-            Matcher exceptionMatcher = EXCEPTION_REGEX.matcher(line);
-            Matcher accessMatcher = ACCESS_REGEX.matcher(line);
-
-            if (constructorMatcher.find()) {
-                // constructors.txt lines are in the form
-                // SRG CLASS SIGNATURE
-
-                // Matches are in the order
-                // .<init> SIGNATURE =|p_i SRG
-                // CLASS is line[0]..match0
-
-                final String className = line.substring(0, constructorMatcher.start(0));
-
-                StringBuilder constructorBuilder = new StringBuilder()
-                    .append(constructorMatcher.group(4)).append(" ")
-                    .append(className).append(" ")
-                    .append(constructorMatcher.group(2));
-
-                constructorLines.add(constructorBuilder.toString());
-                lineMatched = true;
-            }
-
-            if (exceptionMatcher.find()) {
-                // exceptions.txt is in the form
-                // CLASS/FUNCTION (PARAMS)RETURN EXCEPTION
-
-                // Matches are in the order
-                // (PARAMS)RETURN = EXCEPTION |
-
-                final String[] combinedClassMethod = line.substring(0, exceptionMatcher.start(0)).split("\\.");
-                final String className = combinedClassMethod[0];
-                final String methodName = combinedClassMethod[1];
-
-                StringBuilder exceptionBuilder = new StringBuilder()
-                    .append(className).append(" ")
-                    .append(exceptionMatcher.group(1)).append(" ");
-                exceptionBuilder.append(String.join(" ", exceptionMatcher.group(2).split(",")));
-                exceptionLines.add(exceptionBuilder.toString());
-                lineMatched = true;
-            }
-
-            if (accessMatcher.find()) {
-                // access.txt is in the form
-                // ACCESS CLASS OBJECT SIGNATURE
-
-                // accessMatches is in the form
-                // CLASS OBJECT SIGNATURE ACCESS
-                StringBuilder accessBuilder = new StringBuilder()
-                    .append(accessMatcher.group(4)).append(" ")
-                    .append(accessMatcher.group(1)).append(" ")
-                    .append(accessMatcher.group(2)).append(" ")
-                    .append(accessMatcher.group(3));
-
-                accessLines.add(accessBuilder.toString());
-                lineMatched = true;
-            }
-
-            if (!lineMatched) {
-                System.err.println("JoinedExcSplitter: No useful data on line: " + line);
-            }
-        }
+        lines.forEach(line -> parseExcLine(line, constructorLines::add, exceptionLines::add, accessLines::add));
 
         Collections.sort(constructorLines);
         Collections.sort(exceptionLines);
         Collections.sort(accessLines);
 
         return new Result(List.copyOf(constructorLines), List.copyOf(exceptionLines), List.copyOf(accessLines));
+    }
+
+    public static void parseExcLine(String line,
+        Consumer<String> constructorCallback,
+        Consumer<String> exceptionCallback,
+        Consumer<String> accessCallback) {
+        parseExcLine(line, constructorCallback, exceptionCallback, accessCallback, false);
+    }
+
+    public static void parseExcLine(String line,
+        Consumer<String> constructorCallback,
+        Consumer<String> exceptionCallback,
+        Consumer<String> accessCallback,
+        boolean silent) {
+        boolean lineMatched = false;
+        // If we match ".<init>" we're a constructor.
+        Matcher constructorMatcher = CONSTRUCTOR_REGEX.matcher(line);
+        // If we match (SOMETHING)SOMETHING=SOMETHING|, we're an exception line
+        Matcher exceptionMatcher = EXCEPTION_REGEX.matcher(line);
+        Matcher accessMatcher = ACCESS_REGEX.matcher(line);
+
+        if (constructorMatcher.find()) {
+            // constructors.txt lines are in the form
+            // SRG CLASS SIGNATURE
+
+            // Matches are in the order
+            // .<init> SIGNATURE =|p_i SRG
+            // CLASS is line[0]..match0
+            constructorCallback.accept(
+                String.join(" ",
+                    constructorMatcher.group("id"),
+                    constructorMatcher.group("class"),
+                    constructorMatcher.group("desc"))
+            );
+            lineMatched = true;
+        }
+
+        if (exceptionMatcher.find()) {
+            // exceptions.txt is in the form
+            // CLASS/FUNCTION (PARAMS)RETURN EXCEPTION
+
+            // Matches are in the order
+            // (PARAMS)RETURN = EXCEPTION |
+            exceptionCallback.accept(
+                String.join(" ",
+                    exceptionMatcher.group("class"),
+                    exceptionMatcher.group("func"),
+                    exceptionMatcher.group("desc"),
+                    String.join(" ",
+                        exceptionMatcher.group("exceptions").split(","))
+                )
+            );
+            lineMatched = true;
+        }
+
+        if (accessMatcher.find()) {
+            // access.txt is in the form
+            // ACCESS CLASS OBJECT SIGNATURE
+
+            // accessMatches is in the form
+            // CLASS OBJECT SIGNATURE ACCESS
+            accessCallback.accept(
+                String.join(" ",
+                    accessMatcher.group("access"),
+                    accessMatcher.group("class"),
+                    accessMatcher.group("func"),
+                    accessMatcher.group("desc"))
+            );
+            lineMatched = true;
+        }
+
+        if (!lineMatched && !silent) {
+            System.err.println("JoinedExcSplitter: No useful data on line: " + line);
+        }
     }
 
     public static record Result(List<String> constructors, List<String> exceptions, List<String> access) {

--- a/src/test/java/uk/gemwire/mcpconvert/convert/JoinedExcSplitterTest.java
+++ b/src/test/java/uk/gemwire/mcpconvert/convert/JoinedExcSplitterTest.java
@@ -1,0 +1,108 @@
+package uk.gemwire.mcpconvert.convert;
+
+import javax.annotation.Nullable;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class JoinedExcSplitterTest {
+
+    @Test
+    void testConstructors() {
+        testExcLine("com/example/test/TestConstructors.<init>(Ljava/lang/Class;)V=|p_i3141_1_",
+            "3141 com/example/test/TestConstructors (Ljava/lang/Class;)V",
+            null,
+            null);
+
+        testExcLine("com/example/test/TestConstructors.<init>(Ljava/util/function/BiFunction;)Z=|p_i11235_1_",
+            "11235 com/example/test/TestConstructors (Ljava/util/function/BiFunction;)Z",
+            null,
+            null);
+    }
+
+    @Test
+    void testExceptions() {
+        testExcLine("com/example/test/TestExceptions.one(Ljava/lang/Object;)V=java/lang/Exception|",
+            null,
+            "com/example/test/TestExceptions one (Ljava/lang/Object;)V java/lang/Exception",
+            null);
+
+        testExcLine("com/example/test/TestExceptions.two()Ljava/util/function/Function;=java/lang/Exception,java/lang/Error|",
+            null,
+            "com/example/test/TestExceptions two ()Ljava/util/function/Function; java/lang/Exception java/lang/Error",
+            null);
+
+        testExcLine(
+            "com/example/test/TestExceptions.three(Ljava/lang/Error;)Z=org/example/ExampleException," +
+                "java/lang/RuntimeException,java/lang/Error|",
+            null,
+            "com/example/test/TestExceptions three (Ljava/lang/Error;)Z org/example/ExampleException " +
+                "java/lang/RuntimeException java/lang/Error",
+            null);
+    }
+
+    @Test
+    void testAccess() {
+        testExcLine("com/example/test/TestAccess.one(I)Z-Access=PUBLIC",
+            null,
+            null,
+            "PUBLIC com/example/test/TestAccess one (I)Z");
+
+        testExcLine("com/example/test/TestAccess.two(ZZZIZZ)V-Access=PRIVATE",
+            null,
+            null,
+            "PRIVATE com/example/test/TestAccess two (ZZZIZZ)V");
+    }
+
+    @Test
+    void testMixedCE() {
+        testExcLine("com/example/test/TestMixed.<init>(Ljava/lang/ClassLoader;)V=java/lang/Exception|p_i1337_1_",
+            "1337 com/example/test/TestMixed (Ljava/lang/ClassLoader;)V",
+            "com/example/test/TestMixed <init> (Ljava/lang/ClassLoader;)V java/lang/Exception",
+            null);
+    }
+
+    @Test
+    void testMixedCA() {
+        testExcLine("com/example/test/TestMixed.<init>(JLjava/io/InputStream;)V=|p_i756_0_,p_i756_2_-Access=PUBLIC",
+            "756 com/example/test/TestMixed (JLjava/io/InputStream;)V",
+            null,
+            "PUBLIC com/example/test/TestMixed <init> (JLjava/io/InputStream;)V");
+    }
+
+    @Test
+    void testMixedEA() {
+        testExcLine("com/example/test/TestMixed.two(Ljava/util/Optional;)I=java/io/IOException|-Access=PROTECTED",
+            null,
+            "com/example/test/TestMixed two (Ljava/util/Optional;)I java/io/IOException",
+            "PROTECTED com/example/test/TestMixed two (Ljava/util/Optional;)I");
+    }
+
+    @Test
+    void testMixedAll() {
+        testExcLine(
+            "com/example/test/TestMixed.<init>(Jjava/lang/ErrorJZ)V=java/lang/IOException," +
+                "org/example/OopsException|p_i124816_0_,p_i124816_2_p_i124816_3_p_i124816_5_-Access=PROTECTED",
+            "124816 com/example/test/TestMixed (Jjava/lang/ErrorJZ)V",
+            "com/example/test/TestMixed <init> (Jjava/lang/ErrorJZ)V java/lang/IOException org/example/OopsException",
+            "PROTECTED com/example/test/TestMixed <init> (Jjava/lang/ErrorJZ)V");
+    }
+
+    void testExcLine(String line, @Nullable String constructor, @Nullable String exceptions, @Nullable String access) {
+        Result res = testExcLine(line);
+        Assertions.assertEquals(constructor, res.constructor);
+        Assertions.assertEquals(exceptions, res.exceptions);
+        Assertions.assertEquals(access, res.access);
+    }
+
+    Result testExcLine(String line) {
+        String[] results = new String[3];
+        JoinedExcSplitter.parseExcLine(line,
+            constructor -> results[0] = constructor,
+            exceptions -> results[1] = exceptions,
+            access -> results[2] = access);
+        return new Result(results[0], results[1], results[2]);
+    }
+
+    static record Result(@Nullable String constructor, @Nullable String exceptions, @Nullable String access) {}
+}


### PR DESCRIPTION
Refactors `JoinedExcSplitter` to allow calling with any given lines instead of just from a `Path`.
Also adds tests for the different types of lines in the `joined.exc`.