### PR TITLE
Filter out PK declarations from the SRG before TSRG conversion

### DIFF
--- a/src/main/java/uk/gemwire/mcpconvert/Main.java
+++ b/src/main/java/uk/gemwire/mcpconvert/Main.java
@@ -1,7 +1,6 @@
 package uk.gemwire.mcpconvert;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -60,12 +59,10 @@ public class Main {
                 output.getPath("patches/server"));
 
             // Convert joined.srg to joined.tsrg
-            try (InputStream inputStream = Files.newInputStream(mcpData.getPath("joined.srg"))) {
-                System.out.println(" - Converting SRG to TSRG");
-                Path tempTsrg = inMemFS.getPath("config/joined.tsrg");
-                JoinedSrgConverter.convert(inputStream, tempTsrg);
-                Files.copy(tempTsrg, output.getPath("joined.tsrg"));
-            }
+            System.out.println(" - Converting SRG to TSRG");
+            Path tempTsrg = inMemFS.getPath("config/joined.tsrg");
+            JoinedSrgConverter.convert(mcpData.getPath("joined.srg"), inMemFS.getPath("temp.srg"), tempTsrg);
+            Files.copy(tempTsrg, output.getPath("joined.tsrg"));
 
             // Split joined.exc and write to their separate files
             System.out.println(" - Parsing and splitting joined EXC");

--- a/src/main/java/uk/gemwire/mcpconvert/convert/JoinedSrgConverter.java
+++ b/src/main/java/uk/gemwire/mcpconvert/convert/JoinedSrgConverter.java
@@ -2,7 +2,9 @@ package uk.gemwire.mcpconvert.convert;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.stream.Collectors;
 
 import net.minecraftforge.srgutils.IMappingFile;
 
@@ -10,7 +12,16 @@ import net.minecraftforge.srgutils.IMappingFile;
  * @author Sm0keySa1m0n
  */
 public class JoinedSrgConverter {
-    public static void convert(InputStream srgInput, Path tsrgOutput) throws IOException {
-        IMappingFile.load(srgInput).write(tsrgOutput, IMappingFile.Format.TSRG, false);
+    public static void convert(Path srgInput, Path tempFile, Path tsrgOutput) throws IOException {
+        // Filter out the package declarations ('PK: ') from the SRG
+        Files.write(tempFile,
+            Files.lines(srgInput)
+                .filter(str -> !str.startsWith("PK:"))
+                .collect(Collectors.toUnmodifiableList())
+        );
+
+        try (InputStream input = Files.newInputStream(tempFile)) {
+            IMappingFile.load(input).write(tsrgOutput, IMappingFile.Format.TSRG, false);
+        }
     }
 }


### PR DESCRIPTION
An issue I had while configuring MCPConfig was the appearance of a double-dot in the imports of the decompiled source, particularly the imports for the Forge/MCP annotations.
```java
import net..minecraftforge.fml.relauncher.SideOnly;
```
After some tracking down, the root issues seems to be because of the package declarations in the preconversion SRG, which gets converted into the TSRG. These package declarations seems to cause the double-dots in the imports. I do not know the definite reason why, but I suspect it has something to do with the `PK: net net` line.
```
PK: . net/minecraft/src
PK: net net
PK: net/minecraft net/minecraft
PK: net/minecraft/client net/minecraft/client
PK: net/minecraft/client/main net/minecraft/client/main
PK: net/minecraft/realms net/minecraft/realms
PK: net/minecraft/server net/minecraft/server
```
This PR fixes this issue by first reading the SRG and rewriting to a temporary file, with the `PK:` lines filtered out, before passing that into SRGUtils.

We have to write to a temporary file because _a)_ SRGUtils only accepts a `File` or an `InputStream`, and _b)_ trying to convert the filtered lines into a byte array was proving problematic. The method chosen in this PR, writing to a temporary file, avoids those and does not compromise too much on performance, as the temporary file is provided by the caller which gives a temp. file on the in-memory file system.