### PR TITLE
Correct the exceptions format

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ net/minecraft/client/Minecraft.func_71384_a()V=org/lwjgl/LWJGLException,java/io/
 will have the exceptions.txt line
 
 ```
-net/minecraft/client/Minecraft func_71384_a ()V org/lwjgl/LWJGLException java/io/IOException
+net/minecraft/client/Minecraft/func_71384_a ()V org/lwjgl/LWJGLException java/io/IOException
 ```
 
 #### access.txt

--- a/src/main/java/uk/gemwire/mcpconvert/convert/JoinedExcSplitter.java
+++ b/src/main/java/uk/gemwire/mcpconvert/convert/JoinedExcSplitter.java
@@ -84,8 +84,7 @@ public class JoinedExcSplitter {
             // (PARAMS)RETURN = EXCEPTION |
             exceptionCallback.accept(
                 String.join(" ",
-                    exceptionMatcher.group("class"),
-                    exceptionMatcher.group("func"),
+                    exceptionMatcher.group("class") + "/" + exceptionMatcher.group("func"),
                     exceptionMatcher.group("desc"),
                     String.join(" ",
                         exceptionMatcher.group("exceptions").split(","))

--- a/src/main/java/uk/gemwire/mcpconvert/download/MCPData.java
+++ b/src/main/java/uk/gemwire/mcpconvert/download/MCPData.java
@@ -12,7 +12,7 @@ import java.nio.file.StandardCopyOption;
  */
 public class MCPData {
     public static final String MCP_DATA_URL =
-        "https://files.minecraftforge.net/maven/de/oceanlabs/mcp/mcp/{version}/mcp-{version}-srg.zip";
+        "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp/{version}/mcp-{version}-srg.zip";
 
     public static Path provideCachedFile(String version) throws IOException {
         String url = MCP_DATA_URL.replace("{version}", version);

--- a/src/test/java/uk/gemwire/mcpconvert/convert/JoinedExcSplitterTest.java
+++ b/src/test/java/uk/gemwire/mcpconvert/convert/JoinedExcSplitterTest.java
@@ -24,19 +24,19 @@ public class JoinedExcSplitterTest {
     void testExceptions() {
         testExcLine("com/example/test/TestExceptions.one(Ljava/lang/Object;)V=java/lang/Exception|",
             null,
-            "com/example/test/TestExceptions one (Ljava/lang/Object;)V java/lang/Exception",
+            "com/example/test/TestExceptions/one (Ljava/lang/Object;)V java/lang/Exception",
             null);
 
         testExcLine("com/example/test/TestExceptions.two()Ljava/util/function/Function;=java/lang/Exception,java/lang/Error|",
             null,
-            "com/example/test/TestExceptions two ()Ljava/util/function/Function; java/lang/Exception java/lang/Error",
+            "com/example/test/TestExceptions/two ()Ljava/util/function/Function; java/lang/Exception java/lang/Error",
             null);
 
         testExcLine(
             "com/example/test/TestExceptions.three(Ljava/lang/Error;)Z=org/example/ExampleException," +
                 "java/lang/RuntimeException,java/lang/Error|",
             null,
-            "com/example/test/TestExceptions three (Ljava/lang/Error;)Z org/example/ExampleException " +
+            "com/example/test/TestExceptions/three (Ljava/lang/Error;)Z org/example/ExampleException " +
                 "java/lang/RuntimeException java/lang/Error",
             null);
     }
@@ -58,7 +58,7 @@ public class JoinedExcSplitterTest {
     void testMixedCE() {
         testExcLine("com/example/test/TestMixed.<init>(Ljava/lang/ClassLoader;)V=java/lang/Exception|p_i1337_1_",
             "1337 com/example/test/TestMixed (Ljava/lang/ClassLoader;)V",
-            "com/example/test/TestMixed <init> (Ljava/lang/ClassLoader;)V java/lang/Exception",
+            "com/example/test/TestMixed/<init> (Ljava/lang/ClassLoader;)V java/lang/Exception",
             null);
     }
 
@@ -74,7 +74,7 @@ public class JoinedExcSplitterTest {
     void testMixedEA() {
         testExcLine("com/example/test/TestMixed.two(Ljava/util/Optional;)I=java/io/IOException|-Access=PROTECTED",
             null,
-            "com/example/test/TestMixed two (Ljava/util/Optional;)I java/io/IOException",
+            "com/example/test/TestMixed/two (Ljava/util/Optional;)I java/io/IOException",
             "PROTECTED com/example/test/TestMixed two (Ljava/util/Optional;)I");
     }
 
@@ -84,7 +84,7 @@ public class JoinedExcSplitterTest {
             "com/example/test/TestMixed.<init>(Jjava/lang/ErrorJZ)V=java/lang/IOException," +
                 "org/example/OopsException|p_i124816_0_,p_i124816_2_p_i124816_3_p_i124816_5_-Access=PROTECTED",
             "124816 com/example/test/TestMixed (Jjava/lang/ErrorJZ)V",
-            "com/example/test/TestMixed <init> (Jjava/lang/ErrorJZ)V java/lang/IOException org/example/OopsException",
+            "com/example/test/TestMixed/<init> (Jjava/lang/ErrorJZ)V java/lang/IOException org/example/OopsException",
             "PROTECTED com/example/test/TestMixed <init> (Jjava/lang/ErrorJZ)V");
     }
 


### PR DESCRIPTION
#### A small PR to fix the exceptions format
Changes:
- Add a missing slash between the class and method names in the exceptions format
  - Before: `net/minecraft/client/Minecraft func_71384_a ()V org/lwjgl/LWJGLException java/io/IOException`
  - After:   `net/minecraft/client/Minecraft/func_71384_a ()V org/lwjgl/LWJGLException java/io/IOException`
- Update `JoinedExcSplitter`'s tests to the new, correct format
- Bonus: Fix the Forge Maven URL