### PR TITLE
fix: access exc line where the method desc is longer than one character

### DIFF
--- a/src/main/java/uk/gemwire/mcpconvert/convert/JoinedExcSplitter.java
+++ b/src/main/java/uk/gemwire/mcpconvert/convert/JoinedExcSplitter.java
@@ -23,7 +23,7 @@ public class JoinedExcSplitter {
     private static final Pattern EXCEPTION_REGEX =
         compile("(?<class>\\S*)\\.(?<func>\\S*)(?<desc>\\(\\S*\\)\\S*)=(?<exceptions>\\S+)\\|");
     private static final Pattern ACCESS_REGEX =
-        compile("(?<class>\\S*)\\.(?<func>\\S*)(?<desc>\\(\\S*\\)[^=\\s]).*-Access=(?<access>\\S*)");
+        compile("(?<class>\\S*)\\.(?<func>\\S*)(?<desc>\\(\\S*\\)[^=\\s]+).*-Access=(?<access>\\S*)");
 
     public static Result parseExc(Path excFile) throws IOException {
         List<String> lines = Files.readAllLines(excFile, StandardCharsets.UTF_8);

--- a/src/test/java/uk/gemwire/mcpconvert/convert/JoinedExcSplitterTest.java
+++ b/src/test/java/uk/gemwire/mcpconvert/convert/JoinedExcSplitterTest.java
@@ -52,6 +52,12 @@ public class JoinedExcSplitterTest {
             null,
             null,
             "PRIVATE com/example/test/TestAccess two (ZZZIZZ)V");
+
+        testExcLine("com/example/test/TestAccess.three()Lcom/example/test/TestAccess;-Access=PUBLIC",
+            null,
+            null,
+            "PUBLIC com/example/test/TestAccess three ()Lcom/example/test/TestAccess;"
+        );
     }
 
     @Test


### PR DESCRIPTION
This fixes `func_175582_h` or `createCommandManager` in 1.11.x